### PR TITLE
Add repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node __sapper__/build"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,4 @@ you could use it with any pleroma backend
 
 To start a production version of your app, run `npm run build && npm start`. This will disable live reloading, and activate the appropriate bundler plugins.
 
-You can deploy your application to any environment that supports Node 8 or above. As an example, to deploy to [Now](https://zeit.co/now), run these commands:
-
-```bash
-npm install -g now
-now
-```
+[![Run on Repl.it](https://repl.it/badge/github/radio-alice/e-worm)](https://repl.it/github/radio-alice/e-worm)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).